### PR TITLE
Add grail curtain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Some commands were created, accessed by tilting the blind to try to facilitate d
 
 ```
 // cmd 11 - program mode
+// cmd 16 - program mode for grail devices
 // cmd 21 - delete rolling code file
 // cmd 41 - List files
 // cmd 51 - Test filesystem.

--- a/RFsomfy.h
+++ b/RFsomfy.h
@@ -5,6 +5,7 @@ using namespace esphome;
 #include "FS.h"
 
 // cmd 11 - program mode
+// cmd 16 - porgram mode for grail curtains
 // cmd 21 - delete rolling code file
 // cmd 41 - List files
 // cmd 51 - Test filesystem.

--- a/RFsomfy.h
+++ b/RFsomfy.h
@@ -296,6 +296,12 @@ class RFsomfy : public Component, public Cover {
         rtsDevices[remoteId].sendCommandProg();
         delay(1000);
       }
+      if (xpos == 16) {
+        ESP_LOGD("tilt","program mode - grail");
+        digitalWrite(STATUS_LED_PIN, HIGH);
+        rtsDevices[remoteId].sendCommandProgGrail();
+        delay(1000);
+      }
       if (xpos == 21) {
         ESP_LOGD("tilt","delete file");
         digitalWrite(STATUS_LED_PIN, HIGH);

--- a/SomfyRts.cpp
+++ b/SomfyRts.cpp
@@ -170,6 +170,21 @@ void SomfyRts::sendCommandProg() {
     }
 }
 
+// support for grail is limited: I can only pair one remote
+void SomfyRts::sendCommandProgGrail() {
+    buildFrame(_frame, PROG);
+    sendCommand(_frame, 2);
+    for(int i = 0; i<35; i++) {
+      sendCommand(_frame, 7);
+      yield();
+    }
+    for(int i = 0; i<40; i++) {
+      delayMicroseconds(100000);
+      yield();
+    }
+    sendCommandProg();
+}
+
 uint16_t SomfyRts::_readRemoteRollingCode() {
   uint16_t code = 0;
   SPIFFS.begin();

--- a/SomfyRts.h
+++ b/SomfyRts.h
@@ -34,6 +34,7 @@ class SomfyRts {
     void sendCommandDown();
     void sendCommandStop();
     void sendCommandProg();
+    void sendCommandProgGrail();
     void buildFrame(unsigned char *frame, unsigned char button);
     void sendCommand(unsigned char *frame, unsigned char sync);
 };


### PR DESCRIPTION
Grail curtain motors with RTS remote control seem to require a slightly more complicated/slower prog/pairing procedure.
I added cmd 16 to program grail curtain motors